### PR TITLE
removal of late book 8 character spoiler

### DIFF
--- a/assets/data/book-08.json
+++ b/assets/data/book-08.json
@@ -1077,7 +1077,7 @@
     "id": "Jaichim-Carridin",
     "name": "Jaichim Carridin",
     "chapter": "Chapter 28: Crimsonthorn",
-    "info": "Inquisitor for the Hand of the Light, better known as the Questioners; he aspires to some day become High Inquisitor, perhaps even Lord Captain Commander. Surprisingly enough for a Whitecloak, much less a Questioner, Carridin is a Darkfriend. He was given orders (under the name Bors) by Ishamael to find and kill [Rand al'Thor](#Rand-al-Thor), and those orders were strengthened by a Myrddraal who promised to kill another member of Carridin's family every month until al'Thor was dead. So far, Carridin has lost a cousin (found skinned alive in his bed) and his youngest sister Dealda (carried from her bridal feast by a Fade). His older sister, Vanora, recently met with a similar fate. He himself was killed by [Shiaine](#Lady-Shiaine-Avarhin) by drowning with brandy."
+    "info": "Inquisitor for the Hand of the Light, better known as the Questioners; he aspires to some day become High Inquisitor, perhaps even Lord Captain Commander. Surprisingly enough for a Whitecloak, much less a Questioner, Carridin is a Darkfriend. He was given orders (under the name Bors) by Ishamael to find and kill [Rand al'Thor](#Rand-al-Thor), and those orders were strengthened by a Myrddraal who promised to kill another member of Carridin's family every month until al'Thor was dead. So far, Carridin has lost a cousin (found skinned alive in his bed) and his youngest sister Dealda (carried from her bridal feast by a Fade). His older sister, Vanora, recently met with a similar fate."
   },
   {
     "id": "Jak-Fool",


### PR DESCRIPTION
Removes a spoiler for Jaichim Carridin in Path of Daggers. You'll likely look up the character for a refresher RIGHT before the spoiled event occurs but it is still a bit of a shame to have the surprise ruined. 

Thanks for providing us readers the app!